### PR TITLE
spealling in contributions from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ https://www.androidpolice.com/2020/05/27/google-chats-desktop-application-is-now
 See this: [Blazor](https://visualstudiomagazine.com/articles/2019/09/26/blazor-future.aspx), [ElectronCGI](https://www.npmjs.com/package/electron-cgi). 
 
 ## Contributions
-electron-alternatives is open to contributions, but I recommend creating an issue or replying in a comment to let me know what you are working on first that way we don't overwrite each other.
+awesome-electron-alternatives is open to contributions, but I recommend creating an issue or replying in a comment to let me know what you are working on first that way we don't overwrite each other.
 
 Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for details on this project. If you have any questions, feel free to open an issue. And feel free to improve this list by contributing! 
 


### PR DESCRIPTION
Update README.md
- spealling: 'electron-alternatives' to 'awesome-electron-alternatives' in Contributions