### PR TITLE
Remove "Tauri" from "JS/NodeJS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ There are a number of good reasons to avoid Electron or consider something other
 * [nidium](https://www.nidium.com): A powerful rendering engine for modern mobile applications. Unlike many solution, nidium doesn't rely on webviews or native OS widgets. Instead, it uses its own high-performance rendering engine to draw custom widgets.
 * [electrino](https://github.com/pojala/electrino): Desktop runtime for apps built on web technologies, using the system's own web browser engine
 * [graffiti](https://github.com/cztomsik/graffiti): HTML/CSS engine for node.js and deno.
-* [Tauri](https://github.com/tauri-apps/tauri): Build smaller, faster, and more secure desktop applications with a web frontend.
 * [Sciter.JS](https://github.com/c-smile/sciter-js-sdk): Is a 5MB HTML/CSS/JS (ES6) runtime aimed as a direct Electron replacement
 * [Avernakis](https://github.com/qber-soft/Ave-Nodejs) Nodejs addon for Avernakis SDK, use TypeScript to develop modern desktop app with powerful UI kits.
 * [Gluon](https://github.com/gluon-framework/gluon) Uses normal system installed browsers (not webviews) and NodeJS, also supports Firefox


### PR DESCRIPTION
Tauri is duplicated, existing on NodeJS and Rust sections, but only Rust section is correct (Tauri doens't have any NodeJS binding, only interoperability on [@tauri-apps/cli](https://github.com/tauri-apps/tauri/tree/dev/tooling/cli/node)).