### PR TITLE
Add a C++ alternative for Electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ There are a number of good reasons to avoid Electron or consider something other
 * [wxWidgets](https://wxwidgets.org): wxWidgets is a C++ library that lets developers create applications for Windows, macOS, Linux and other platforms with a single code base. It has popular language bindings for Python, Ruby, Lua, Perl and several other languages
 * [sciter](https://sciter.com): Embeddable HTML/CSS/JavaScript engine for modern UI development
 * [Ultralight](https://ultralig.ht): Ultra-fast, ultra-light, standards-compliant HTML renderer for applications and games. Based on WebKit— supports most modern HTML5, CSS, and JavaScript features while still remaining light and configurable.
-* [Webview](https://github.com/webview/webview): Tiny cross-platform webview library which uses Cocoa/WebKit on macOS, gtk-webkit2 on Linux and Edge on Windows 10
+* [Webview](https://github.com/webview/webview): Tiny cross-platform webview library which uses Cocoa/WebKit on macOS, gtk-webkit2 on Linux and Edge on Windows 10.
+* [Molybden](https://teamdev.com/molybden): An SDK for building modern and secure cross-desktop apps with HTML/CSS/JavaScript GUI.
 
 ### Crystal
 * [Crystal Webview](https://github.com/naqvis/webview): Crystal language bindings for [webview](https://github.com/webview/webview), a tiny cross-platform webview library which uses Cocoa/WebKit on macOS, gtk-webkit2 on Linux and Edge on Windows 10)


### PR DESCRIPTION
Add Molybden SDK that represents "Electron for C++ developers" to the list of C/C++ alternatives.